### PR TITLE
Fix handler path in serverless.yml

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -33,7 +33,7 @@ package:
 
 functions:
   lambda_handler:
-    handler: handler.lambda_handler
+    handler: src/handler.lambda_handler
     timeout: 900
     events:
       - schedule:


### PR DESCRIPTION
## チケットへのリンク

* https://example.com

## 変更点概要

- handler.pyのパスを修正したが、serverless.yml側の修正を忘れていたので対応

## 動作確認

- AWSコンソールから関数を実行し、設定したSlackチャンネルにメッセージが送信されることを確認した

## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

