### PR TITLE
Slackメッセージが黄色になる条件を変更(5.0$以上)

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -43,7 +43,7 @@ def build_slack_message(metric_statistics):
     if float(cost) >= 10.0:
         # red
         color = "#ff0000"
-    elif float(cost) > 0.0:
+    elif float(cost) > 5.0:
         # yellow
         color = "warning"
     else:

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -31,7 +31,7 @@ class HandlerTest(unittest.TestCase):
         self.assertEqual("#ff0000", slack_message["attachments"][0]["color"])
 
     def test_build_slack_message_yellow(self):
-        metric_statistics = {"Datapoints": [{"Maximum": 9.9}]}
+        metric_statistics = {"Datapoints": [{"Maximum": 5.0}]}
         slack_message = handler.build_slack_message(metric_statistics)
 
         self.assertEqual("AWSどるちぇっかー", slack_message["username"])


### PR DESCRIPTION
## チケットへのリンク



## 変更点概要

- Slackメッセージが黄色になる条件を、AWS使用料が5$以上のとき2変更

## 動作確認

- Lambda関数を更新してテストを実行

<img width="492" alt="スクリーンショット 2021-01-03 9 52 58" src="https://user-images.githubusercontent.com/31530938/103469547-7dc7f400-4da9-11eb-936b-b6f4513334fe.png">


## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）

